### PR TITLE
Update JWT signing algorithm for consistency and security

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,14 +11,7 @@ import { AuthGuard } from './guard/auth.guard';
 
 @Module({
   imports: [
-    JwtModule.registerAsync({
-      global: true,
-      imports: [ConfigModule],
-      useFactory: async (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET'),
-      }),
-      inject: [ConfigService],
-    }),
+    JwtModule.register({ global: true }),
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -32,17 +32,20 @@ export class AuthService {
     // accessToken
     const accessToken = await this.jwtService.signAsync(payload, {
       privateKey,
+      algorithm: 'RS256',
       expiresIn: '10 minutes',
     });
     // refreshToken
     const refreshToken = await this.jwtService.signAsync(payload, {
       privateKey,
+      algorithm: 'RS256',
       expiresIn: '7 days',
     });
     // verify accessToken
     await this.jwtService
       .verifyAsync(accessToken, { publicKey })
       .catch((error) => {
+        console.error(error);
         throw new UnauthorizedException('Invalid access token', error);
       });
 
@@ -93,7 +96,7 @@ export class AuthService {
     };
 
     const { privateKey, publicKey } = generateKeyPairSync('rsa', {
-      modulusLength: 1024,
+      modulusLength: 2048,
       publicKeyEncoding: {
         type: 'spki',
         format: 'pem',


### PR DESCRIPTION
This pull request updates the JWT signing algorithm to use RS256 for both access tokens and refresh tokens. Previously, the algorithm was not specified, which could lead to inconsistencies and potential security vulnerabilities. The update ensures that both tokens are signed using the same algorithm, enhancing the overall security of the application.