### PR TITLE
Remove refresh_token_used field and change fuln to not nullable

### DIFF
--- a/src/db/migrations/1718632333489-edit_field_email_of_user_table_to_not_nullable.ts
+++ b/src/db/migrations/1718632333489-edit_field_email_of_user_table_to_not_nullable.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class EditFieldEmailOfUserTableToNotNullable1718632333489 implements MigrationInterface {
+    name = 'EditFieldEmailOfUserTableToNotNullable1718632333489'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "fuln" SET NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "fuln" DROP NOT NULL`);
+    }
+
+}

--- a/src/entity/user.entity.ts
+++ b/src/entity/user.entity.ts
@@ -24,7 +24,7 @@ export class User {
   avatar: string;
   @Column('varchar', { length: 125, nullable: true })
   email: string;
-  @Column('varchar', { length: 30, nullable: true })
+  @Column('varchar', { length: 30, nullable: false })
   fuln: string;
   @Column('varchar', { length: 20, nullable: true })
   phone: number;


### PR DESCRIPTION
This pull request removes the `refresh_token_used` field of the key object in Redis to make maintenance easier and reduce storage usage. It also changes the `fuln` field of the User table to be not nullable.