### PR TITLE
Refactor findAll method in BlogsController to accept a page parameter

### DIFF
--- a/src/blogs/blogs.controller.ts
+++ b/src/blogs/blogs.controller.ts
@@ -93,7 +93,6 @@ export class BlogsController {
   }
   @Get('workspace-info')
   getWorkspaceListByUser(@User() user: DecodeUser) {
-    console.log('find');
     return this.blogsService.getWorkspaceList(user);
   }
   @Get(':blog_id')
@@ -151,8 +150,8 @@ export class BlogsController {
   }
 
   @Get()
-  async findAll() {
-    return await this.blogsService.findAll();
+  async findAll(@Query('page') page: string) {
+    return await this.blogsService.findAll(+page);
   }
 
   @Get('for/user')

--- a/src/blogs/blogs.service.ts
+++ b/src/blogs/blogs.service.ts
@@ -31,6 +31,8 @@ import { BlogRating } from 'src/entity/blog-rating.entity';
 
 @Injectable()
 export class BlogsService {
+  private readonly LIMIT = 12;
+
   constructor(
     @InjectRepository(User) private readonly userRepository: Repository<User>,
     @InjectRepository(Blog) private readonly blogRepository: Repository<Blog>,
@@ -284,10 +286,18 @@ export class BlogsService {
     return { success: true, message: 'Blog removed successfully' };
   }
 
-  async findAll() {
+  async findAll(page = 1) {
+    const skip = (page - 1) * this.LIMIT;
+
     const blogs = await this.blogRepository.find({
       relations: relationsBlog,
+      order: {
+        crd_at: 'DESC',
+      },
+      skip,
+      take: this.LIMIT,
     });
+
     return blogs;
   }
 

--- a/src/blogs/blogs.service.ts
+++ b/src/blogs/blogs.service.ts
@@ -290,12 +290,12 @@ export class BlogsService {
     const skip = (page - 1) * this.LIMIT;
 
     const blogs = await this.blogRepository.find({
+      skip,
+      take: this.LIMIT,
       relations: relationsBlog,
       order: {
         crd_at: 'DESC',
       },
-      skip,
-      take: this.LIMIT,
     });
 
     return blogs;


### PR DESCRIPTION
This pull request updates the findAll method in the BlogsController to accept a page parameter. Previously, the method returned all blogs, but now it supports pagination by allowing the user to specify the page number. The page parameter is used to skip the appropriate number of blogs and limit the results to a fixed number per page.