### PR TITLE
Fix find blog and find workspace by ID

### DIFF
--- a/src/blogs/blogs.controller.ts
+++ b/src/blogs/blogs.controller.ts
@@ -104,8 +104,8 @@ export class BlogsController {
     type: 'string',
     required: true,
   })
-  findOne(@Param('blog_id') id: string) {
-    return this.blogsService.findBlogByID(id);
+  findOne(@Param('blog_id') id: string, @User() user: DecodeUser) {
+    return this.blogsService.findBlogByID(id, user);
   }
 
   @Patch(':blog_id')

--- a/src/blogs/blogs.service.ts
+++ b/src/blogs/blogs.service.ts
@@ -22,7 +22,7 @@ import {
   selectBlog,
 } from 'src/lib/constant/blog';
 import { DecodeUser } from 'src/lib/type';
-import { generateUUID, getRandomBlogs } from 'src/lib/utils';
+import { canPassThrough, generateUUID, getRandomBlogs } from 'src/lib/utils';
 import { CreateBlogDTO } from './dto/create-blog.dto';
 import { CreateBlogCommentDTO } from './dto/crete-blog-comment.dto';
 import { UpdateBlogDTO } from './dto/update-blog.dto';
@@ -170,7 +170,7 @@ export class BlogsService {
     };
   }
 
-  async findBlogByID(id: string) {
+  async findBlogByID(id: string, user: DecodeUser) {
     const blog = await this.blogRepository.findOne({
       where: { blog_id: id },
       relations: relationsBlog,
@@ -178,6 +178,21 @@ export class BlogsService {
     });
 
     if (!blog) throw new NotFoundException('Blog not found');
+
+    if (blog.workspace) {
+      const userInsideWorkspace = blog.workspace.users.map((u) => u.user);
+      const isUserInWorkspace = userInsideWorkspace.some(
+        (u) => u.user_id === user.user_id,
+      );
+
+      const isMA = canPassThrough(user, { onApprove: true, onDecline: false });
+
+      if (!isUserInWorkspace && !isMA) {
+        throw new ForbiddenException('User does not belong to the workspace');
+      }
+
+      delete blog.workspace.users;
+    }
 
     return blog;
   }
@@ -254,7 +269,7 @@ export class BlogsService {
       upd_user_id: user.user_id,
     });
 
-    return this.findBlogByID(blog_id);
+    return this.findBlogByID(blog_id, user);
   }
 
   async remove(blog_id: string, user: DecodeUser) {

--- a/src/lib/constant/blog.ts
+++ b/src/lib/constant/blog.ts
@@ -12,7 +12,11 @@ export const relationsBlog = {
     user: true,
   },
 
-  workspace: true,
+  workspace: {
+    users: {
+      user: true,
+    },
+  },
   resource: true,
 };
 
@@ -48,6 +52,10 @@ export const selectBlog = {
   blogRatings: selectBlogRatings,
   user: selectUser,
   tags: selectTag,
+  workspace: {
+    wksp_id: true,
+    wksp_name: true,
+  },
 };
 
 export const blogRelationWithUser = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,6 @@
 import helmet from 'helmet';
-import {
-  WinstonModule,
-  utilities as nestWinstonModuleUtilities,
-} from 'nest-winston';
+import { utilities as winstonUtilities, WinstonModule } from 'nest-winston';
+import * as winston from 'winston';
 
 import { HttpStatus, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -10,7 +8,7 @@ import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 import { AppModule } from './app.module';
-import * as winston from 'winston';
+
 import DailyRotateFile = require('winston-daily-rotate-file');
 
 async function bootstrap() {
@@ -22,7 +20,7 @@ async function bootstrap() {
           format: winston.format.combine(
             winston.format.timestamp(),
             winston.format.ms(),
-            nestWinstonModuleUtilities.format.nestLike('Synergy Server', {
+            winstonUtilities.format.nestLike('Synergy Server', {
               colors: true,
               prettyPrint: true,
               processId: true,
@@ -42,10 +40,7 @@ async function bootstrap() {
   });
 
   const config = app.get(ConfigService);
-  app.enableCors({
-    origin: '*',
-    credentials: true,
-  });
+  app.enableCors({ origin: '*' });
   app.use(helmet());
   app.setGlobalPrefix('api');
   app.useGlobalPipes(
@@ -62,6 +57,9 @@ async function bootstrap() {
     .addTag('Auth', 'Endpoints for authentication')
     .addTag('Users', 'Endpoints for users management')
     .addTag('Blogs', 'Endpoints for blogs management')
+    .addTag('Workspaces', 'Endpoints for workspaces management')
+    .addTag('Resources', 'Endpoints for resources management')
+    .addTag('Notifications', 'Endpoints for notifications management')
     .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, configSwagger);

--- a/src/resources/resources.controller.ts
+++ b/src/resources/resources.controller.ts
@@ -14,8 +14,15 @@ import { RolesGuard } from 'src/guard/roles.guard';
 import { Roles } from 'src/decorator/roles.decorator';
 import { User } from 'src/decorator/user.decorator';
 import { DecodeUser } from 'src/lib/type';
+import { ApiBearerAuth, ApiHeader, ApiTags } from '@nestjs/swagger';
 @UseGuards(RolesGuard)
 @Controller('resources')
+@ApiBearerAuth()
+@ApiHeader({
+  name: 'x-user-id',
+  required: true,
+})
+@ApiTags('Resources')
 export class ResourcesController {
   constructor(private readonly resourcesService: ResourcesService) {}
 

--- a/src/workspaces/workspaces.controller.ts
+++ b/src/workspaces/workspaces.controller.ts
@@ -24,7 +24,7 @@ import { DecodeUser } from 'src/lib/type';
 import { RemoveMemberDTO } from './dto/remove-member.dto';
 @UseGuards(RolesGuard)
 @ApiBearerAuth()
-@ApiTags('workspaces')
+@ApiTags('Workspaces')
 @ApiHeader({
   name: 'x-user-id',
   required: true,
@@ -70,8 +70,8 @@ export class WorkspacesController {
 
   // get specific workspace
   @Get(':wksp_id')
-  getWorkspace(@Param('wksp_id') wksp_id: string) {
-    return this.workspacesService.getOneWorkspace(wksp_id);
+  getWorkspace(@Param('wksp_id') wksp_id: string, @User() user: DecodeUser) {
+    return this.workspacesService.getOneWorkspace(wksp_id, user);
   }
 
   // Soft delete workspace

--- a/src/workspaces/workspaces.service.ts
+++ b/src/workspaces/workspaces.service.ts
@@ -143,7 +143,7 @@ export class WorkspacesService {
       throw new ForbiddenException('Get workspace failed');
     }
   }
-  async getOneWorkspace(wksp_id: string) {
+  async getOneWorkspace(wksp_id: string, user: DecodeUser) {
     const result = await this.workspaceRepository.findOne({
       select: {
         wksp_id: true,
@@ -204,6 +204,11 @@ export class WorkspacesService {
       },
     });
     if (!result) throw new NotFoundException('Workspace not found');
+    if (
+      !result.users.some((u) => u.user.user_id === user.user_id) &&
+      !canPassThrough(user, { onApprove: true, onDecline: false })
+    )
+      throw new ForbiddenException('Permission denied');
     const workspace = {
       ...result,
       users: removeFalsyFields(


### PR DESCRIPTION
This pull request fixes the issues with finding a blog and finding a workspace by ID. The `findOne` method in the `BlogsController` now accepts an additional `user` parameter, and the `findBlogByID` method in the `BlogsService` also accepts the `user` parameter. The `getWorkspace` method in the `WorkspacesController` also accepts the `user` parameter. These changes ensure that the user's permission is checked when finding a blog or a workspace by ID.